### PR TITLE
Permit to depend on Fluentd v0.14

### DIFF
--- a/fluent-plugin-output-solr.gemspec
+++ b/fluent-plugin-output-solr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'fluentd', '~> 0.12.32'
+  spec.add_runtime_dependency 'fluentd', ['>= 0.12.32', '< 2']
   spec.add_runtime_dependency 'rsolr-cloud', '~> 1.1.0'
   spec.add_runtime_dependency 'rsolr', '~> 1.0.12'
   spec.add_runtime_dependency 'zk', '~> 1.9.5'


### PR DESCRIPTION
Fluentd v0.14, which is the next version of stable, will ship with td-agent3 near future.
Any chance to permit to depend on Fluentd v0.14?
Thanks.