### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-output-solr.gemspec
+++ b/fluent-plugin-output-solr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'fluentd', '~> 0.12.32'
+  spec.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 2']
   spec.add_runtime_dependency 'rsolr-cloud', '~> 1.1.0'
   spec.add_runtime_dependency 'rsolr', '~> 1.0.12'
   spec.add_runtime_dependency 'zk', '~> 1.9.5'

--- a/lib/fluent/plugin/out_solr.rb
+++ b/lib/fluent/plugin/out_solr.rb
@@ -91,7 +91,7 @@ module Fluent::Plugin
     end
 
     def format(tag, time, record)
-      [tag, time, record].to_msgpack
+      [time, record].to_msgpack
     end
 
     def formatted_to_msgpack_binary
@@ -107,8 +107,8 @@ module Fluent::Plugin
 
       @fields = @defined_fields.nil? ? get_fields : @defined_fields
       @unique_key = @unique_key_field.nil? ? get_unique_key : @unique_key_field
-
-      chunk.msgpack_each do |tag, time, record|
+      tag = chunk.metadata.tag
+      chunk.msgpack_each do |time, record|
         record = inject_values_to_record(tag, time, record)
 
         unless record.has_key?(@unique_key) then

--- a/lib/fluent/plugin/out_solr.rb
+++ b/lib/fluent/plugin/out_solr.rb
@@ -2,24 +2,25 @@ require 'securerandom'
 require 'rsolr'
 require 'zk'
 require 'rsolr/cloud'
+require 'fluent/plugin/output'
 
-module Fluent
-  class SolrOutput < BufferedOutput
+module Fluent::Plugin
+  class SolrOutput < Output
     Fluent::Plugin.register_output('solr', self)
+
+    helpers :inject, :compat_parameters
 
     DEFAULT_COLLECTION = 'collection1'
     DEFAULT_IGNORE_UNDEFINED_FIELDS = false
     DEFAULT_TAG_FIELD = 'tag'
     DEFAULT_TIMESTAMP_FIELD = 'event_timestamp'
     DEFAULT_FLUSH_SIZE = 100
+    DEFAULT_BUFFER_TYPE = "memory"
 
     MODE_STANDALONE = 'Standalone'
     MODE_SOLRCLOUD = 'SolrCloud'
 
-    include Fluent::SetTagKeyMixin
     config_set_default :include_tag_key, false
-
-    include Fluent::SetTimeKeyMixin
     config_set_default :include_time_key, false
 
     config_param :url, :string, :default => nil,
@@ -31,9 +32,9 @@ module Fluent
                  :desc => 'The SolrCloud collection name (default collection1).'
 
     config_param :defined_fields, :array, :default => nil,
-                 :desc => 'The defined fields in the Solr schema.xml. If omitted, it will get fields via Solr Schema API.'                 
+                 :desc => 'The defined fields in the Solr schema.xml. If omitted, it will get fields via Solr Schema API.'
     config_param :ignore_undefined_fields, :bool, :default => DEFAULT_IGNORE_UNDEFINED_FIELDS,
-                 :desc => 'Ignore undefined fields in the Solr schema.xml.'                 
+                 :desc => 'Ignore undefined fields in the Solr schema.xml.'
 
     config_param :unique_key_field, :string, :default => nil,
                  :desc => 'A field name of unique key in the Solr schema.xml. If omitted, it will get unique key via Solr Schema API.'
@@ -45,11 +46,17 @@ module Fluent
     config_param :flush_size, :integer, :default => DEFAULT_FLUSH_SIZE,
                  :desc => 'A number of events to queue up before writing to Solr (default 100).'
 
+    config_section :buffer do
+      config_set_default :@type, DEFAULT_BUFFER_TYPE
+      config_set_default :chunk_keys, ['tag']
+    end
+
     def initialize
       super
     end
 
     def configure(conf)
+      compat_parameters_convert(conf, :inject)
       super
     end
 
@@ -87,6 +94,14 @@ module Fluent
       [tag, time, record].to_msgpack
     end
 
+    def formatted_to_msgpack_binary
+      true
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
     def write(chunk)
       documents = []
 
@@ -94,6 +109,8 @@ module Fluent
       @unique_key = @unique_key_field.nil? ? get_unique_key : @unique_key_field
 
       chunk.msgpack_each do |tag, time, record|
+        record = inject_values_to_record(tag, time, record)
+
         unless record.has_key?(@unique_key) then
           record.merge!({@unique_key => SecureRandom.uuid})
         end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
 require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,6 +22,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
+require 'fluent/test/driver/output'
 
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new

--- a/test/plugin/test_output-solr.rb
+++ b/test/plugin/test_output-solr.rb
@@ -1,6 +1,8 @@
 require 'helper'
 
 class SolrOutputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
   def setup
     Fluent::Test.setup
     @zk_server = nil
@@ -87,7 +89,7 @@ class SolrOutputTest < Test::Unit::TestCase
   end
 
   def test_format_standalone
-    time = Time.parse("2016-01-01 09:00:00 UTC").to_i
+    time = event_time("2016-01-01 09:00:00 UTC")
 
     stub_solr_update 'http://localhost:8983/solr/collection1/update?commit=true&wt=ruby'
 
@@ -101,7 +103,7 @@ class SolrOutputTest < Test::Unit::TestCase
   def test_format_solrcloud
     start_zookeeper
 
-    time = Time.parse("2016-01-01 09:00:00 UTC").to_i
+    time = event_time("2016-01-01 09:00:00 UTC")
 
     stub_solr_update 'http://localhost:8983/solr/collection1/update?commit=true&wt=ruby'
 
@@ -117,7 +119,7 @@ class SolrOutputTest < Test::Unit::TestCase
   def test_write_standalone
     d = create_driver
 
-    time = Time.parse("2016-01-01 09:00:00 UTC").to_i
+    time = event_time("2016-01-01 09:00:00 UTC")
 
     stub_solr_update 'http://localhost:8983/solr/collection1/update?commit=true&wt=ruby'
 
@@ -138,7 +140,7 @@ class SolrOutputTest < Test::Unit::TestCase
 
     d = create_driver
 
-    time = Time.parse("2016-01-01 09:00:00 UTC").to_i
+    time = event_time("2016-01-01 09:00:00 UTC")
 
     stub_solr_update 'http://localhost:8983/solr/collection1/update?commit=true&wt=ruby'
 

--- a/test/plugin/test_output-solr.rb
+++ b/test/plugin/test_output-solr.rb
@@ -95,7 +95,7 @@ class SolrOutputTest < Test::Unit::TestCase
     d.run(default_tag: "test") do
       d.feed(time, sample_record)
     end
-    assert_equal "\x93\xA4test\xCEV\x86@\x10\x82\xA2id\xA9change.me\xA5title\xA9change.me".force_encoding("ascii-8bit"), d.formatted[0]
+    assert_equal [time, sample_record].to_msgpack, d.formatted[0], d.formatted[0]
   end
 
   def test_format_solrcloud
@@ -109,7 +109,7 @@ class SolrOutputTest < Test::Unit::TestCase
     d.run(default_tag: "test") do
       d.feed(time, sample_record)
     end
-    assert_equal "\x93\xA4test\xCEV\x86@\x10\x82\xA2id\xA9change.me\xA5title\xA9change.me".force_encoding("ascii-8bit"), d.formatted[0]
+    assert_equal [time, sample_record].to_msgpack, d.formatted[0]
 
     stop_zookeeper
   end

--- a/test/plugin/test_output-solr.rb
+++ b/test/plugin/test_output-solr.rb
@@ -27,8 +27,8 @@ class SolrOutputTest < Test::Unit::TestCase
     flush_size              100
   ]
 
-  def create_driver(conf = CONFIG_STANDALONE, tag='test')
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::SolrOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG_STANDALONE)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::SolrOutput).configure(conf)
   end
 
   def sample_record
@@ -92,9 +92,10 @@ class SolrOutputTest < Test::Unit::TestCase
     stub_solr_update 'http://localhost:8983/solr/collection1/update?commit=true&wt=ruby'
 
     d = create_driver CONFIG_STANDALONE
-    d.emit(sample_record, time)
-    d.expect_format "\x93\xA4test\xCEV\x86@\x10\x82\xA2id\xA9change.me\xA5title\xA9change.me".force_encoding("ascii-8bit")
-    d.run
+    d.run(default_tag: "test") do
+      d.feed(time, sample_record)
+    end
+    assert_equal "\x93\xA4test\xCEV\x86@\x10\x82\xA2id\xA9change.me\xA5title\xA9change.me".force_encoding("ascii-8bit"), d.formatted[0]
   end
 
   def test_format_solrcloud
@@ -105,9 +106,10 @@ class SolrOutputTest < Test::Unit::TestCase
     stub_solr_update 'http://localhost:8983/solr/collection1/update?commit=true&wt=ruby'
 
     d = create_driver CONFIG_SOLRCLOUD
-    d.emit(sample_record, time)
-    d.expect_format "\x93\xA4test\xCEV\x86@\x10\x82\xA2id\xA9change.me\xA5title\xA9change.me".force_encoding("ascii-8bit")
-    d.run
+    d.run(default_tag: "test") do
+      d.feed(time, sample_record)
+    end
+    assert_equal "\x93\xA4test\xCEV\x86@\x10\x82\xA2id\xA9change.me\xA5title\xA9change.me".force_encoding("ascii-8bit"), d.formatted[0]
 
     stop_zookeeper
   end
@@ -124,8 +126,9 @@ class SolrOutputTest < Test::Unit::TestCase
     #d.instance.unique_key_field = 'id'
     #d.instance.defined_fields = ['id', 'title']
 
-    d.emit(sample_record, time)
-    d.run
+    d.run(default_tag: "test") do
+      d.feed(time, sample_record)
+    end
 
     assert_equal('<?xml version="1.0" encoding="UTF-8"?><add><doc><field name="id">change.me</field><field name="title">change.me</field></doc></add>', @index_cmds)
   end
@@ -144,12 +147,13 @@ class SolrOutputTest < Test::Unit::TestCase
     #d.instance.unique_key_field = 'id'
     #d.instance.defined_fields = ['id', 'title']
 
-    d.emit(sample_record, time)
-    d.run
+    d.run(default_tag: "test") do
+      d.feed(time, sample_record)
+    end
 
     assert_equal('<?xml version="1.0" encoding="UTF-8"?><add><doc><field name="id">change.me</field><field name="title">change.me</field></doc></add>', @index_cmds)
 
-    stop_zookeeper  
+    stop_zookeeper
   end
 
   def start_zookeeper


### PR DESCRIPTION
In v0.14, Fluentd plugins can handle nanosecond precision time and reduce chunk size with v0.14 style chunk metadata.
Could you consider to use v0.14 style API?
Thanks.