### PR TITLE
Add a missing invalid chunk_keys verificartion in #configure

### DIFF
--- a/lib/fluent/plugin/out_solr.rb
+++ b/lib/fluent/plugin/out_solr.rb
@@ -62,6 +62,7 @@ module Fluent::Plugin
     def configure(conf)
       compat_parameters_convert(conf, :inject)
       super
+      raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
     end
 
     def start

--- a/test/plugin/test_output-solr.rb
+++ b/test/plugin/test_output-solr.rb
@@ -104,6 +104,27 @@ class SolrOutputTest < Test::Unit::TestCase
     assert_equal [time, sample_record].to_msgpack, d.formatted[0], d.formatted[0]
   end
 
+  def test_invalid_chunk_keys
+    assert_raise_message(/'tag' in chunk_keys is required./) do
+      create_driver(Fluent::Config::Element.new(
+                      'ROOT', '', {
+                        '@type'                   => 'solr',
+                        'url'                     => 'http://localhost:8983/solr/collection1',
+                        'defined_fields'          => '["id", "title"]',
+                        'ignore_undefined_fields' => true,
+                        'unique_key_field'        => 'id',
+                        'tag_field'               => 'tag',
+                        'timestamp_field'         => 'event_timestamp',
+                        'flush_size'              => 100,
+                        'commit_with_flush'       => true
+                      }, [
+                        Fluent::Config::Element.new('buffer', 'mykey', {
+                                                      'chunk_keys' => 'mykey'
+                                                    }, [])
+                      ]))
+    end
+  end
+
   def test_format_solrcloud
     start_zookeeper
 


### PR DESCRIPTION
In #2, I've forgot to add `tag` existence checking in `#configure`.
Fluentd plugins should check its config parameter validity in `#configure`.
Sorry for inconvenience.

Thanks, 